### PR TITLE
Update edit post handling

### DIFF
--- a/feed/post/index.html
+++ b/feed/post/index.html
@@ -59,7 +59,7 @@
                             <p>Back to feed</p>
                         </a>
                     </div>
-                    <section class="row border rounded pt-3 mb-3 bg-white">
+                    <section class="row border rounded pt-3 mb-3 bg-white" id="updateDelete">
                         <p class="d-inline-flex gap-2">
                             <button class="btn btn-primary" type="button" data-bs-toggle="collapse" data-bs-target="#editPost" aria-expanded="false" aria-controls="editPost">Edit post</button>
                             <button class="btn btn-danger" type="submit" id="deleteButton">Delete post</button>

--- a/feed/post/index.html
+++ b/feed/post/index.html
@@ -59,7 +59,7 @@
                             <p>Back to feed</p>
                         </a>
                     </div>
-                    <section class="row border rounded pt-3 mb-3 bg-white" id="updateDelete">
+                    <section class="row border rounded pt-3 mb-3 bg-white" id="updateDelete" style="display: none;">
                         <p class="d-inline-flex gap-2">
                             <button class="btn btn-primary" type="button" data-bs-toggle="collapse" data-bs-target="#editPost" aria-expanded="false" aria-controls="editPost">Edit post</button>
                             <button class="btn btn-danger" type="submit" id="deleteButton">Delete post</button>

--- a/src/js/handlers/editPost.mjs
+++ b/src/js/handlers/editPost.mjs
@@ -1,17 +1,43 @@
 import { getPost } from "../api/posts/get.mjs";
 import { updatePost } from "../api/posts/update.mjs"
+import { load } from "../storage/storageHandler.mjs";
 
+// Function to check if the author of the post is the logged in user
+async function isUserLoggedIn(postAuthor) {
+    const { name } = await load("profile");
+    return postAuthor === name;
+}
+
+// Function to show or hide the updateDelete section on view post by ID page based on logged-in status
+async function showUpdateDeleteSection(postAuthor) {
+    const updateDeleteSection = document.getElementById("updateDelete");
+    if (await isUserLoggedIn(postAuthor)) {
+        updateDeleteSection.style.display = 'block';
+    } else {
+        updateDeleteSection.style.display = 'none';
+    }
+}
+
+// Function to set up the edit post form with event listeners
 export async function setEditPostFormListener () {
-    const form = document.querySelector("#edit-post");
-
     const url = new URL (location.href);
     const id = url.searchParams.get("id");
+
+    const post = await getPost(id);
+
+    await showUpdateDeleteSection(post.author.name);
+
+    if (!await isUserLoggedIn(post.author.name)) {
+        return;
+    }
+
+    const form = document.querySelector("#edit-post");
 
     if (form) {
         const button = form.querySelector("button");
         button.disabled = true;
 
-        const post = await getPost(id);
+       
 
         form.title.value = post.title;
         form.body.value = post.body;


### PR DESCRIPTION
This PR adds an update to the edit post handler:
- functionality added so that the edit and delete option only shows when the logged-in user is the author of the post when viewing a single post by ID.